### PR TITLE
Remove the 'accumulate' generator.

### DIFF
--- a/src/contracts/IGenerators.ts
+++ b/src/contracts/IGenerators.ts
@@ -5,5 +5,4 @@ export interface IGenerators {
     range(parameters?: Partial<RangeParams>): ILazyCollection<number, undefined, undefined>;
     randomInt(lessThan: number): ILazyCollection<number, undefined, undefined>;
     circular<T>(iterable: Iterable<T>): ILazyCollection<T, undefined, undefined>;
-    accumulate(initial?: number): Generator<number, undefined, number>;
 }

--- a/src/generators/accumulate.ts
+++ b/src/generators/accumulate.ts
@@ -1,5 +1,0 @@
-export function* accumulate(initial = 0): Generator<number, undefined, number> {
-    while (true) {
-        initial += yield initial;
-    }
-}

--- a/src/generators/index.ts
+++ b/src/generators/index.ts
@@ -1,4 +1,3 @@
-export * from "./accumulate";
 export * from "./append";
 export * from "./chunk";
 export * from "./circular";

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -18,7 +18,6 @@ const Lazy: ILazy = {
         range: (parameters?: Partial<λ.RangeParams>): ILazyCollection<number, undefined, undefined> => chain(λ.range(parameters)),
         randomInt: (lessThan: number): ILazyCollection<number, undefined, undefined> => chain(λ.randomInt(lessThan)),
         circular: <T>(iterable: Iterable<T>): ILazyCollection<T, undefined, undefined> => chain(λ.circular(iterable)),
-        accumulate: (initial?: number): Generator<number, undefined, number> => λ.accumulate(initial),
     },
     generate: <T, R, N> (func: () => T): ILazyCollection<T, R | undefined, N> => chain(λ.generate(func)),
 };

--- a/src/tests/generators/accumulate.test.ts
+++ b/src/tests/generators/accumulate.test.ts
@@ -1,1 +1,0 @@
-// TODO: Write tests


### PR DESCRIPTION
This generator would not be so useful, so we decided to remove it. You can still implement your own generator for accumulating, with the 'generate' method.